### PR TITLE
Improve the performance of loading a compilation database.

### DIFF
--- a/compilationDatabase.cxx
+++ b/compilationDatabase.cxx
@@ -18,6 +18,8 @@ void Application::compilationDatabase (CompilationDatabaseArgs & args,
           << reader.getFormattedErrorMessages();
   }
 
+  auto transaction(storage_.beginTransaction());
+
   for (unsigned int i=0 ; i<root.size() ; ++i) {
     std::string fileName = root[i]["file"].asString();
     std::string directory = root[i]["directory"].asString();

--- a/sqlite++/CMakeLists.txt
+++ b/sqlite++/CMakeLists.txt
@@ -1,7 +1,9 @@
 ct_push_dir (${CT_DIR}/sqlite++)
 
 add_library (sqlite++
-  ${CT_DIR}/database.cxx)
+  ${CT_DIR}/database.cxx
+  ${CT_DIR}/transaction.cxx
+)
 set (LIBS ${LIBS} sqlite++)
 
 add_executable (test_sqlite++

--- a/sqlite++/sqlite.hxx
+++ b/sqlite++/sqlite.hxx
@@ -1,6 +1,7 @@
 #pragma once
 #include "database.hxx"
 #include "statement.hxx"
+#include "transaction.hxx"
 
 /** @addtogroup sqlite Sqlite++
 

--- a/sqlite++/tests/test_sqlite++.cxx
+++ b/sqlite++/tests/test_sqlite++.cxx
@@ -23,12 +23,14 @@ int main () {
                     "  name  TEXT"
                     ")");
 
+  {
+    Transaction transaction(database);
 
-  // Prepare an SQL statement with a placeholder, ...
-  database.prepare ("INSERT INTO foo VALUES (NULL, ?)")
-    .bind ("bar")  // bind it to a value, ...
-    .step ();      // execute it
-
+    // Prepare an SQL statement with a placeholder, ...
+    database.prepare ("INSERT INTO foo VALUES (NULL, ?)")
+      .bind ("bar")  // bind it to a value, ...
+      .step ();      // execute it
+  }
 
   // Prepare an SQL statement
   Statement statement = database.prepare ("SELECT id, name FROM foo");

--- a/sqlite++/transaction.cxx
+++ b/sqlite++/transaction.cxx
@@ -1,0 +1,15 @@
+#include "transaction.hxx"
+
+#include "database.hxx"
+
+namespace Sqlite {
+  Transaction::Transaction (Database & db)
+    : db_(db)
+  {
+    db_.execute("BEGIN TRANSACTION");
+  }
+
+  Transaction::~Transaction () {
+    db_.execute("END TRANSACTION");
+  }
+}

--- a/sqlite++/transaction.hxx
+++ b/sqlite++/transaction.hxx
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace Sqlite {
+  class Database;
+
+  /** @addtogroup sqlite
+      @{
+  */
+
+  /** @brief SQL transaction
+   *
+   * The transaction is automatically ended when the object is destroyed.
+   */
+  class Transaction {
+  public:
+    /** @brief Constructor
+     *
+     * Begin a transaction on a given SQLite database connection.
+     *
+     * @param db SQLite database connection.
+     * @throw Error
+     */
+    Transaction (Database & db);
+
+    /** @brief Destructor
+     *
+     * End the transaction.
+     */
+    ~Transaction ();
+
+  private:
+    Database & db_;
+  };
+
+  /** @} */
+}

--- a/storage.hxx
+++ b/storage.hxx
@@ -127,12 +127,8 @@ public:
     db_.execute ("UPDATE files SET indexed = 0");
   }
 
-  void beginIndex () {
-    db_.execute ("BEGIN TRANSACTION");
-  }
-
-  void endIndex () {
-    db_.execute ("END TRANSACTION");
+  Sqlite::Transaction beginTransaction () {
+    return Sqlite::Transaction(db_);
   }
 
   bool beginFile (const std::string & fileName) {


### PR DESCRIPTION
With these changes, running `clang-tags load` now takes 0.98s instead of 2m 21s on a project with about 230 source files.
