### PR TITLE
Limit the memory usage of the translation unit cache.

### DIFF
--- a/clang-tags
+++ b/clang-tags
@@ -66,7 +66,8 @@ def start (args):
         sys.exit (1)
 
     print "Starting server..."
-    command = ["sh", "-c", "clang-tags-server >%s 2>&1 &" % logPath]
+    command = ["sh", "-c", "clang-tags-server --cachesize %d >%s 2>&1 &" %
+        (args.cachesize, logPath)]
     sys.exit (subprocess.call (command))
 
 
@@ -337,6 +338,12 @@ def main_argparse ():
         "start",
         help = "start the clang-tags server",
         description = "Start the clang-tags server.")
+    s.add_argument (
+        "--cachesize",
+        metavar = "CACHESIZE",
+        type = int,
+        help = "Specify the maximum size of the translation unit cache (in MB)")
+    s.set_defaults (cachesize = 1000000)
     s.set_defaults (fun = start)
 
     s = subparsers.add_parser (

--- a/libclang++/CMakeLists.txt
+++ b/libclang++/CMakeLists.txt
@@ -3,6 +3,7 @@ ct_push_dir (${CT_DIR}/libclang++)
 add_library (clang++
   ${CT_DIR}/index.cxx
   ${CT_DIR}/translationUnit.cxx
+  ${CT_DIR}/translationUnitCache.cxx
   ${CT_DIR}/sourceLocation.cxx
   ${CT_DIR}/cursor.cxx)
 set (LIBS ${LIBS} clang++)

--- a/libclang++/translationUnit.cxx
+++ b/libclang++/translationUnit.cxx
@@ -45,6 +45,20 @@ namespace LibClang {
     return res;
   }
 
+  unsigned long TranslationUnit::memoryUsage () const {
+    CXTUResourceUsage usage = clang_getCXTUResourceUsage (raw());
+    unsigned long total = 0;
+
+    for (unsigned int i = 0; i < usage.numEntries; ++i)
+    {
+      const CXTUResourceUsageEntry & entry = usage.entries[i];
+      total += entry.amount;
+    }
+
+    clang_disposeCXTUResourceUsage(usage);
+    return total;
+  }
+
   const CXTranslationUnit & TranslationUnit::raw () const {
     return translationUnit_->translationUnit_;
   }

--- a/libclang++/translationUnit.hxx
+++ b/libclang++/translationUnit.hxx
@@ -85,6 +85,12 @@ namespace LibClang {
      */
     std::string diagnostic (unsigned int i);
 
+    /** @brief Get the memory usage of the translation unit.
+     *
+     * @return The memory usage (in bytes) of the translation unit.
+     */
+    unsigned long memoryUsage () const;
+
     // TODO Make this method private
     const CXTranslationUnit & raw () const;
 

--- a/libclang++/translationUnitCache.cxx
+++ b/libclang++/translationUnitCache.cxx
@@ -1,0 +1,42 @@
+#include "translationUnitCache.hxx"
+
+namespace LibClang {
+  TranslationUnitCache::TranslationUnitCache (unsigned long memoryLimit)
+    : memoryLimit_(memoryLimit),
+      memoryUsage_(0)
+  {
+  }
+
+  bool TranslationUnitCache::contains (const std::string & fileName) const {
+    return tunits_.find(fileName) != tunits_.end();
+  }
+
+  void TranslationUnitCache::insert (const std::string & fileName,
+      const TranslationUnit & tu) {
+
+    memoryUsage_ += tu.memoryUsage();
+
+    // Clear out recently-used files until we have enough space for the new
+    // translation unit.
+    while (memoryUsage_ > memoryLimit_ && !lruFiles_.empty()) {
+      auto it = tunits_.find(lruFiles_.front());
+      memoryUsage_ -= it->second.first.memoryUsage();
+      tunits_.erase(it);
+      lruFiles_.pop_front();
+    }
+
+    // Add in our new translation unit. Even if the memory usage of this single
+    // translation unit exceeds the memory limit, we will always insert it.
+    auto it = lruFiles_.emplace(lruFiles_.end(), fileName);
+    tunits_.emplace(fileName, std::make_pair(tu, it));
+  }
+
+  TranslationUnit & TranslationUnitCache::get (const std::string & fileName) {
+    auto & entry = tunits_.find(fileName)->second;
+
+    // Move this file to the end of the least-recently-used list.
+    lruFiles_.splice(lruFiles_.end(), lruFiles_, entry.second);
+
+    return entry.first;
+  }
+}

--- a/libclang++/translationUnitCache.hxx
+++ b/libclang++/translationUnitCache.hxx
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "translationUnit.hxx"
+#include <list>
+#include <map>
+
+namespace LibClang {
+  /** @addtogroup libclang
+   * @{
+   */
+
+  /** @brief Provides caching of @c TranslationUnit instances.
+   *
+   * This class provides a memory-limited cache of translation units. When the
+   * memory limit is exceeded, the least recently-used translation units are
+   * disposed.
+   */
+  class TranslationUnitCache {
+  public:
+    /** @brief Constructor
+     *
+     * @param memoryLimit The maximum memory usage (in bytes) of the cache.
+     */
+    TranslationUnitCache (unsigned long memoryLimit);
+
+    /** @brief Determine whether a cache entry exists.
+     *
+     * @return true if the cache contains a translation unit corresponding to
+     * the given filename.
+     */
+    bool contains (const std::string & fileName) const;
+
+    /** @brief Add a new translation unit to the cache.
+     *
+     * Inserts the translation unit into the cache, and possibly disposes older translation
+     * units in order to satisfy the memory usage limit.
+     */
+    void insert (const std::string & fileName, const TranslationUnit & tu);
+
+    /** @brief Retrieve a translation unit from the cache.
+     *
+     * Use @m contains() to first determine whether the cache entry exists.
+     */
+    TranslationUnit & get (const std::string & fileName);
+
+  private:
+    const unsigned long memoryLimit_;
+    unsigned long memoryUsage_;
+
+    typedef std::list<std::string> LRUFileList;
+    LRUFileList lruFiles_;
+    std::map<std::string, std::pair<TranslationUnit, LRUFileList::iterator>> tunits_;
+  };
+
+  /** @} */
+}

--- a/main.cxx
+++ b/main.cxx
@@ -218,6 +218,8 @@ int main (int argc, char **argv) {
                "print this help message and exit");
   options.add ("stdin", 's', 0,
                "read a request from the standard input and exit");
+  options.add ("cachesize", 'l', 1,
+               "specify the maximum size of the translation unit cache (in MB)");
 
   try {
     options.get();
@@ -231,9 +233,22 @@ int main (int argc, char **argv) {
     return 0;
   }
 
+  // Default to a cache of 1GB.
+  unsigned long cacheLimit = 1024;
+  if (options.getCount ("cachesize") > 0) {
+    try {
+      cacheLimit = std::stoul(options["cachesize"]);
+    } catch (...) {
+      std::cerr << "Invalid cachesize value: " << options["cachesize"] << std::endl;
+      return 1;
+    }
+  }
+
+  // Convert to bytes from MB.
+  cacheLimit *= 1024 * 1024;
 
   Storage storage;
-  Application app (storage);
+  Application app (storage, cacheLimit);
   Request::Parser p ("Clang-tags server\n");
   p .add (new CompilationDatabaseCommand ("load", app))
     .add (new IndexCommand ("index", app))


### PR DESCRIPTION
Fixes issue #4.

Just to note, there is a fair bit of memory usage outside of the translation unit cache. In my test with the cache limited to 500MB, the memory usage of `clang-tags-server` ended up growing to around 700MB while indexing.
