### PR TITLE
Add an `isDefn` field to the tags table in the database (and fix a warning)

### DIFF
--- a/cmake/Modules/FindLibclang.cmake
+++ b/cmake/Modules/FindLibclang.cmake
@@ -1,10 +1,10 @@
 find_path (Libclang_INCLUDE_DIR clang-c/Index.h
   HINTS "${LIBCLANG_ROOT}/include"
-  PATH  "/usr/lib/llvm-3.2/include")
+  PATH  "/usr/lib/llvm-3.5/include")
 
 find_library (Libclang_LIBRARY clang
   HINTS "${LIBCLANG_ROOT}/lib"
-  PATH  "/usr/lib/llvm-3.2/lib")
+  PATH  "/usr/lib/llvm-3.5/lib")
 
 set (Libclang_LIBRARIES    ${Libclang_LIBRARY})
 set (Libclang_INCLUDE_DIRS ${Libclang_INCLUDE_DIR})

--- a/index.cxx
+++ b/index.cxx
@@ -67,7 +67,7 @@ public:
       storage_.addTag (usr, cursor.kindStr(), cursor.spelling(), fileName,
                        begin.line, begin.column, begin.offset,
                        end.line,   end.column,   end.offset,
-                       cursor.isDeclaration());
+                       cursor.isDeclaration(), cursor.isDefinition());
     }
 
     return CXChildVisit_Recurse;

--- a/libclang++/cursor.cxx
+++ b/libclang++/cursor.cxx
@@ -34,6 +34,10 @@ namespace LibClang {
     return clang_isDeclaration(clang_getCursorKind(raw()));
   }
 
+  bool Cursor::isDefinition () const {
+    return clang_isCursorDefinition(raw());
+  }
+
   Cursor Cursor::referenced () const {
     return clang_getCursorReferenced (raw());
   }

--- a/libclang++/cursor.hxx
+++ b/libclang++/cursor.hxx
@@ -73,6 +73,12 @@ namespace LibClang {
      */
     bool isDeclaration () const;
 
+    /** @brief Determine whether the cursor represents a definition
+     *
+     * @return true if the cursor represents a definition
+     */
+    bool isDefinition () const;
+
     /** @brief Get the cursor referenced
      *
      * For cursors which represent references to other entities in the AST,

--- a/request/request.hxx
+++ b/request/request.hxx
@@ -337,7 +337,7 @@ namespace Request {
 
     virtual void set (const Json::Value & json) {
       destination_.resize (json.size());
-      for (int i = 0 ; i<json.size() ; ++i) {
+      for (unsigned i = 0 ; i<json.size() ; ++i) {
         setValue (json[i], destination_[i]);
       }
     }

--- a/storage.hxx
+++ b/storage.hxx
@@ -39,7 +39,8 @@ public:
                  "  line2    INTEGER,"
                  "  col2     INTEGER,"
                  "  offset2  INTEGER,"
-                 "  isDecl   BOOLEAN"
+                 "  isDecl   BOOLEAN,"
+                 "  isDefn   BOOLEAN"
                  ")");
     db_.execute ("CREATE TABLE IF NOT EXISTS options ( "
                  "  name   TEXT, "
@@ -220,7 +221,8 @@ public:
                const std::string & fileName,
                const int line1, const int col1, const int offset1,
                const int line2, const int col2, const int offset2,
-               bool isDeclaration) {
+               bool isDeclaration,
+               bool isDefinition) {
     int fileId = fileId_ (fileName);
     if (fileId == -1) {
       return;
@@ -234,11 +236,11 @@ public:
                    "  AND offset2=?")
       .bind (fileId).bind (usr).bind (offset1).bind (offset2);
     if (stmt.step() == SQLITE_DONE) { // no matching row
-      db_.prepare ("INSERT INTO tags VALUES (?,?,?,?,?,?,?,?,?,?,?)")
+      db_.prepare ("INSERT INTO tags VALUES (?,?,?,?,?,?,?,?,?,?,?,?)")
         .bind(fileId) .bind(usr)  .bind(kind)    .bind(spelling)
         .bind(line1)  .bind(col1) .bind(offset1)
         .bind(line2)  .bind(col2) .bind(offset2)
-        .bind(isDeclaration)
+        .bind(isDeclaration) .bind(isDefinition)
         .step();
     }
   }


### PR DESCRIPTION
This patch extends the sqlite database with a new field `isDefn`, which is populated by calling the libclang API function

```
unsigned clang_isCursorDefinition (CXCursor)
```

A potential issue with this patch is that the database is not versioned, and if the new server is run against an old database, things silently fail.  I don't know  if a return code from sqlite is not being checked or exactly what the issue might be.

Ideally an API version number would be stored in the database and if the server detects an old database, a new column would be added (and perhaps all the tags entries removed).  Unfortunately I don't know  nough sqlite to make this happen.  But if you want to pursue it, I can ask for help.

I also don't know how to extend the internal unit tests to test for this case.  But 'make test' continues to  pass, and I have eyeballed a database for my application and the results look good!

The patch also fixes a compiler warning.
